### PR TITLE
added more descriptive named methods

### DIFF
--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -115,11 +115,7 @@ class Paystack
      */
     public function createAuthorizationUrl($data = null)
     {
-        $this->makePaymentRequest($data);
-
-        $this->url = $this->getResponse()['authorization_url'];
-
-        return $this;
+        return $this->getAuthorizationUrl($data = null);
     }
 
     /**

--- a/src/Paystack.php
+++ b/src/Paystack.php
@@ -107,7 +107,23 @@ class Paystack
     }
 
     /**
-     * Get the authorization url from the callback response.
+     * Create the authorization url from the callback response.
+     *
+     * @param null $data
+     *
+     * @return Paystack
+     */
+    public function createAuthorizationUrl($data = null)
+    {
+        $this->makePaymentRequest($data);
+
+        $this->url = $this->getResponse()['authorization_url'];
+
+        return $this;
+    }
+
+    /**
+     * Create the authorization url from the callback response.
      *
      * @param null $data
      *
@@ -120,6 +136,16 @@ class Paystack
         $this->url = $this->getResponse()['authorization_url'];
 
         return $this;
+    }
+
+    /**
+     * Get the authorization url from the callback response.
+     *
+     * @return String
+     */
+    public function getAuthorizedUrl()
+    {
+        return $this->url;
     }
 
     /**
@@ -193,6 +219,14 @@ class Paystack
      * Fluent method to redirect to Paystack Payment Page.
      */
     public function redirectNow()
+    {
+        return redirect($this->url);
+    }
+
+    /**
+     * Another Fluent method to redirect to Paystack Payment Page.
+     */
+    public function redirectToAuthorizedUrl()
     {
         return redirect($this->url);
     }


### PR DESCRIPTION
This PR seeks to add more descriptive method naming to two previous methods and adds one fresh method.

`createAuthorizationUrl($data = null)` which handles just creation of the authorized url 
`getAuthorizedUrl()` which returns the authorized url value
`redirectToAuthorizedUrl()` which redirects to the authorized url value

in use 
`$this->createAuthorizedUrl($data)->getAuthorizedUrl()` 
or 
`$this->createAuthorizedUrl($data)->redirectToAuthorizedUrl()`

This does not eliminate the previous `getAuthorizationUrl($data = null)` or `redirectNow()`  methods, it only adds alternative options.